### PR TITLE
Improve session creation workflow and add iTerm support

### DIFF
--- a/bin/clawtree
+++ b/bin/clawtree
@@ -220,7 +220,7 @@ function create_session() {
       copy_preserved_files "$path"
     fi
     
-    open_session "$(basename "$path")"
+    echo "🎉 Session ready! Return to main menu to launch it."
   else
     echo "❌ Failed to create worktree. The branch '$branch' may already exist."
   fi
@@ -237,6 +237,33 @@ function delete_session() {
   }
 }
 
+function launch_in_terminal() {
+  local path="$1"
+  local claude_cmd="$2"
+  
+  osascript <<EOF
+tell application "Terminal"
+  do script "cd \"$path\" && $claude_cmd"
+  activate
+end tell
+EOF
+}
+
+function launch_in_iterm() {
+  local path="$1"
+  local claude_cmd="$2"
+  
+  osascript <<EOF
+tell application "iTerm2"
+  create window with default profile
+  tell current session of current window
+    write text "cd \"$path\" && $claude_cmd"
+  end tell
+  activate
+end tell
+EOF
+}
+
 function open_session() {
   session="$1"
   path="$SESSIONS_DIR/$session"
@@ -245,7 +272,7 @@ function open_session() {
   claude_cmd="claude --model sonnet"
   
   # Quick launch options - only show if we have common use cases
-  launch_option=$(gum choose --header "Launch Claude with:" "🚀 Standard" "⚡ Skip permissions" "🔄 Resume session" "⚙️ Custom flags")
+  launch_option=$(gum choose --header "Launch Claude with:" "🚀 Standard" "⚡ Skip permissions" "🔄 Resume session" "⚙️ Custom flags" "❌ Cancel")
   
   case $launch_option in
     "⚡ Skip permissions")
@@ -262,17 +289,34 @@ function open_session() {
         claude_cmd="claude --model sonnet"
       fi
       ;;
+    "❌ Cancel")
+      return  # Exit without launching anything
+      ;;
     *)
       claude_cmd="claude --model sonnet"
       ;;
   esac
-
-  osascript <<EOF
-tell application "Terminal"
-  do script "cd \"$path\" && $claude_cmd"
-  activate
-end tell
-EOF
+  
+  # Choose terminal application
+  terminal_choice=$(gum choose --header "Choose terminal:" "💻 Terminal" "🚀 iTerm" "❌ Cancel")
+  
+  case $terminal_choice in
+    "💻 Terminal")
+      launch_in_terminal "$path" "$claude_cmd"
+      ;;
+    "🚀 iTerm")
+      # Check if iTerm is installed
+      if ! osascript -e 'tell application "System Events" to return (exists application process "iTerm2")' 2>/dev/null && ! ls /Applications/iTerm.app 2>/dev/null >/dev/null; then
+        echo "⚠️  iTerm not found. Falling back to Terminal."
+        launch_in_terminal "$path" "$claude_cmd"
+      else
+        launch_in_iterm "$path" "$claude_cmd"
+      fi
+      ;;
+    "❌ Cancel")
+      return  # Exit without launching anything
+      ;;
+  esac
 }
 
 function open_vscode() {


### PR DESCRIPTION
## Summary

- 🔄 **Better UX Flow**: Session creation now returns to main menu instead of auto-launching
- 🖥️ **iTerm Support**: Choose between Terminal or iTerm2 when launching Claude sessions
- ❌ **Proper Cancellation**: Cancel options actually cancel without forced behavior
- 🧹 **Cleaner Architecture**: Separated terminal launching into dedicated functions

## Problem Solved

**Before**: Create session → forced into launch dialog → Terminal opens even if canceled  
**After**: Create session → return to menu → choose session → choose options → choose terminal

## Workflow Improvements

### 1. **No More Auto-Launch**
- Session creation shows "🎉 Session ready\! Return to main menu to launch it."
- User stays in control of when/how to launch sessions

### 2. **iTerm Support** 
- Choose between "🖥️ Terminal" or "🚀 iTerm" when launching Claude
- Auto-detects iTerm installation with graceful fallback
- Proper iTerm2 AppleScript integration

### 3. **True Cancellation**
- "❌ Cancel" options in both Claude settings and terminal choice
- No forced terminal opening when user doesn't want to launch

## Technical Changes

```bash
# New separated functions
launch_in_terminal()   # Original Terminal.app support
launch_in_iterm()      # New iTerm2 support with proper AppleScript

# Improved flow
create_session() → return to menu (no auto-launch)
open_session() → Claude options → Terminal choice → launch
```

## Test Plan

- [ ] Create a new session and verify it returns to main menu
- [ ] Select session and verify Claude launch options work
- [ ] Test Terminal launching works as before  
- [ ] Test iTerm launching (if iTerm installed)
- [ ] Test iTerm fallback to Terminal (if iTerm not installed)
- [ ] Verify Cancel buttons actually cancel without launching anything

🤖 Generated with [Claude Code](https://claude.ai/code)